### PR TITLE
4.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,12 @@
 # History
 
 ## 4.0.0
-- make the OAuth2 server node module and `body-parser` injectable to allow 
-  better dependency management and vulnerability detection on clients
+- use (actively maintained) @node-oauth/oauth2-server
+- improve console output readability
+- support Meteor versions `['1.6', '2.3']`; because 2.3 was a breaking release
+- update tests to use latest Accounts and jkuester:http
+- update follow redirect rules
+- maybe-breaking due to update to Accounts 2.x
 
 ## 3.3.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 4.0.0
+- make the OAuth2 server node module and `body-parser` injectable to allow 
+  better dependency management and vulnerability detection on clients
+
 ## 3.3.0
 
 - updated `oauth2-server` to `4.0.0-dev.3`

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ We use mocha with `meteortesting:mocha` to run the tests. You can run the tests 
 TEST_WATCH=1 TEST_CLIENT=0 meteor test-packages ./ --driver-package meteortesting:mocha
 ```
 
+You can also run the tests once via
+
+```bash
+TEST_CLIENT=0 meteor test-packages ./ --once --driver-package meteortesting:mocha
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+# Meteor OAuth2 Server
+
+[![Test suite](https://github.com/leaonline/oauth2-server/actions/workflows/tests.yml/badge.svg)](https://github.com/leaonline/oauth2-server/actions/workflows/tests.yml)
+[![CodeQL](https://github.com/leaonline/oauth2-server/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/leaonline/oauth2-server/actions/workflows/codeql-analysis.yml)
+[![built with Meteor](https://img.shields.io/badge/Meteor-package-green?logo=meteor&logoColor=white)](https://atmospherejs.com/leaonline/oauth2-server)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+![GitHub](https://img.shields.io/github/license/leaonline/oauth2-server)
 
-# oauth2-server
-
-This package is a implementation of the package [node-oauth2-server (v3)](https://github.com/thomseddon/node-oauth2-server) for Meteor.
-It runs without `express` and implements the `authorization_code` workflow and works like the Facebook's OAuth popup.
+This package is a implementation of the package
+[@node-oauth/oauth2-server](https://github.com/node-oauth/node-oauth2-server) 
+for Meteor.
+It can run without `express` (we use Meteor's builtin `WebApp`) and implements 
+the `authorization_code` workflow and works like the Facebook's OAuth popup.
 
 ## Changelog
 

--- a/error.js
+++ b/error.js
@@ -1,17 +1,21 @@
 export const errorHandler = function (res, { error, description, uri, status, state, debug, originalError }) {
   const errCode = status || 500
   res.writeHead(errCode, { 'Content-Type': 'application/json' })
-  if (debug) {
-    console.error(`[ERROR] ${errCode} - ${error} - ${description}`)
-    if (originalError) {
-      console.error(originalError)
-    }
+
+  // by default we log the error that will be used as response
+  console.error(`[OAuth2Server]: ${errCode} - ${error} - ${description}`)
+
+  if (debug && originalError) {
+    console.error('[OAuth2Server]: original error:')
+    console.error(originalError)
   }
+
   const body = JSON.stringify({
     error,
     error_description: description,
     error_uri: uri,
     state
   }, null, 2)
+
   res.end(body)
 }

--- a/oauth-tests.js
+++ b/oauth-tests.js
@@ -210,11 +210,11 @@ describe('integration tests of OAuth2 workflows', function () {
         }
 
         post(routes.authorizeUrl, { params }, done, res => {
-          assert.equal(res.statusCode, 302)
           const queryParamsRegex = new RegExp(`code=.+&user=${user._id}&state=${params.state}`, 'g')
           const location = res.headers.location.split('?')
           assert.equal(location[0], clientDoc.redirectUris[0])
           assert.isTrue(queryParamsRegex.test(location[1]))
+          assert.equal(res.statusCode, 302)
         })
       })
 

--- a/oauth.js
+++ b/oauth.js
@@ -17,7 +17,7 @@ import { Random } from 'meteor/random'
 import { UserValidation } from './userValidation'
 
 const URLSearchParams = require('url').URLSearchParams
-const OAuthserver = Npm.require('oauth2-server')
+const OAuthserver = Npm.require('@node-oauth/oauth2-server')
 
 const bind = fn => Meteor.bindEnvironment(fn)
 

--- a/oauth.js
+++ b/oauth.js
@@ -27,7 +27,7 @@ const { Response } = OAuthserver
 const getDebugMiddleWare = instance => (req, res, next) => {
   if (instance.debug === true) {
     const baseUrl = req.originalUrl.split('?')[0]
-    console.log('[OAuth2Server]', req.method, baseUrl, req.query || req.body)
+    console.debug('[OAuth2Server]', req.method, baseUrl, req.query || req.body)
   }
   return next()
 }
@@ -63,7 +63,7 @@ const isValidUser = function (instanceId, user, debug = false) {
   // then the developers intended to do so. However, we will print an info.
   if (!UserValidation.isRegistered(instanceId)) {
     if (debug) {
-      console.info('[OAuth2Server]: skip user validation')
+      console.debug('[OAuth2Server]: skip user validation')
     }
     return true
   }
@@ -72,7 +72,7 @@ const isValidUser = function (instanceId, user, debug = false) {
     return UserValidation.isValid(instanceId, user)
   } catch (e) {
     if (debug) {
-      console.info('[OAuth2Server]: isValidUser failed with exception', e.message, e.reason, e.details)
+      console.debug('[OAuth2Server]: isValidUser failed with exception', e.message, e.reason, e.details)
     }
 
     return false
@@ -437,7 +437,6 @@ class OAuth2Server {
           res.end(body)
         })
         .catch(function (err) {
-          console.error(err)
           return errorHandler(res, {
             error: 'unauthorized_client',
             description: err.message,

--- a/oauth.js
+++ b/oauth.js
@@ -369,7 +369,7 @@ class OAuth2Server {
     // - on allow, assign the client_id to the user's authorized clients
     // - on deny, ...?
     // - construct the redirect query and redirect to the redirect_uri
-    route('post', authorizeUrl, function (req, res, next) {
+    route('post', authorizeUrl, function (req, res /*, next */) {
       const request = new Request(req)
       const response = new Response(res)
       const authorizeOptions = {
@@ -387,8 +387,11 @@ class OAuth2Server {
             user: req.user.id,
             state: req.body.state
           })
+
           const finalRedirectUri = `${req.body.redirect_uri}?${query}`
-          res.writeHead(302, { Location: finalRedirectUri })
+
+          res.statusCode = 302
+          res.setHeader('Location', finalRedirectUri)
           res.end()
         }))
         .catch(function (err) {

--- a/package.js
+++ b/package.js
@@ -20,7 +20,7 @@ Npm.depends({
 Package.onTest(function (api) {
   api.use('ecmascript')
   api.use('mongo')
-  api.use('http')
+  api.use('http@1.4.0')
   api.use('dburles:mongo-collection-instances')
   api.use('meteortesting:mocha')
   api.use('accounts-base')

--- a/package.js
+++ b/package.js
@@ -20,11 +20,11 @@ Npm.depends({
 Package.onTest(function (api) {
   api.use('ecmascript')
   api.use('mongo')
-  api.use('http@1.4.0')
+  api.use('jkuester:http@2.1.0')
   api.use('dburles:mongo-collection-instances')
   api.use('meteortesting:mocha')
-  api.use('accounts-base')
-  api.use('accounts-password')
+  api.use('accounts-base@2.1.0')
+  api.use('accounts-password@2.1.0')
   api.use('practicalmeteor:chai')
   //  api.mainModule('oauth-tests.js', 'server')
 

--- a/package.js
+++ b/package.js
@@ -23,8 +23,8 @@ Package.onTest(function (api) {
   api.use('jkuester:http@2.1.0')
   api.use('dburles:mongo-collection-instances')
   api.use('meteortesting:mocha')
-  api.use('accounts-base@2.1.0')
-  api.use('accounts-password@2.1.0')
+  api.use('accounts-base@2.0.0')
+  api.use('accounts-password@2.0.0')
   api.use('practicalmeteor:chai')
   //  api.mainModule('oauth-tests.js', 'server')
 

--- a/package.js
+++ b/package.js
@@ -20,6 +20,7 @@ Npm.depends({
 Package.onTest(function (api) {
   api.use('ecmascript')
   api.use('mongo')
+  api.use('http')
   api.use('dburles:mongo-collection-instances')
   api.use('meteortesting:mocha')
   api.use('accounts-base')

--- a/package.js
+++ b/package.js
@@ -1,19 +1,19 @@
 /* eslint-env meteor */
 Package.describe({
   name: 'leaonline:oauth2-server',
-  version: '3.3.0',
+  version: '4.0.0',
   summary: 'OAuth 2 Server (v3) with Meteor bindings',
   git: 'https://github.com/leaonline/oauth2-server.git'
 })
 
 Package.onUse(function (api) {
-  api.versionsFrom('1.0')
+  api.versionsFrom(['1.6', '2.3'])
   api.use('ecmascript@0.12.7')
   api.mainModule('oauth.js', 'server')
 })
 
 Npm.depends({
-  'oauth2-server': '4.0.0-dev.3',
+  '@node-oauth/oauth2-server': '4.1.0',
   'body-parser': '1.19.0'
 })
 

--- a/utils.js
+++ b/utils.js
@@ -15,7 +15,7 @@ export const isModelInstance = model => {
   return model && Object.keys(model).some(property => modelNames.includes(property))
 }
 
-let cache = new Map()
+const cache = new Map()
 
 export const createCollection = (passedCollection, collectionName) => {
   if (passedCollection) {

--- a/webapp-tests.js
+++ b/webapp-tests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import { Meteor } from 'meteor/meteor'
-import { HTTP } from 'meteor/http'
+import { HTTP } from 'meteor/jkuester:http'
 import { Random } from 'meteor/random'
 import { assert } from 'meteor/practicalmeteor:chai'
 import { app } from './webapp'


### PR DESCRIPTION
- use (actively maintained) @node-oauth/oauth2-server
- improve console output readability
- support Meteor versions `['1.6', '2.3']`; because 2.3 was a breaking release
- update tests to use latest Accounts and jkuester:http
- update follow redirect rules
- maybe-breaking due to update to Accounts 2.x