### PR TITLE
fix: acces token post response expires_in field wasn't sending an integer

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -470,6 +470,14 @@ const initRoutes = (self, {
 
       try {
         const token = await self.oauth.token(request, response)
+        let expires_in;
+        if (token.accessTokenExpiresAt != null) {
+            const expiresAtMs = new Date(token.accessTokenExpiresAt).getTime()
+            if (!Number.isNaN(expiresAtMs)) {
+                // RFC 6749 §4.2.2 / §5.1: expires_in is lifetime in seconds from response time
+                expires_in = Math.max(0, Math.floor((expiresAtMs - Date.now()) / 1000))
+            }
+        }
         res
           .set({
             'Content-Type': 'application/json',
@@ -480,7 +488,8 @@ const initRoutes = (self, {
           .json({
             access_token: token.accessToken,
             token_type: 'bearer',
-            expires_in: token.accessTokenExpiresAt,
+            expires_in: expires_in,
+            expires_at: token.accessTokenExpiresAt,
             refresh_token: token.refreshToken
           })
       } catch (err) {


### PR DESCRIPTION
moved `accessTokenExpiresAt` to `expires_at` and added `expires_in` which is the lifetime in seconds of the access token as per RFC 6749

```
   expires_in
         RECOMMENDED.  The lifetime in seconds of the access token.  For
         example, the value "3600" denotes that the access token will
         expire in one hour from the time the response was generated.
         If omitted, the authorization server SHOULD provide the
         expiration time via other means or document the default value.
```

@jankapunkt let me know if you think this could be merged. Thanks ! 